### PR TITLE
Fix

### DIFF
--- a/template_website/assets/css/style.css
+++ b/template_website/assets/css/style.css
@@ -25,6 +25,13 @@ body {
   font-weight: normal;
   font-style: normal;
   color: #121212; }
+  /* fix overflow for smaller devicess */
+  @media(max-width:768px) {
+    body{
+      overflow-x: hidden;
+      max-width: 100%;
+    }
+  }
 
 * {
   margin: 0;

--- a/template_website/index.html
+++ b/template_website/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
 
     <!--====== Title ======-->
-    <title>Smash - Bootstrap Business Template</title>
+    <title>AnitaBorg | Open Source</title>
 
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
1. I edited the page title from Smash - Bootstrap Business Template to AnitaBorg | Open Source. Reason: You already maintained the footer credits for the template,the page title should be descriptive.
2. Fixed overflow-x for smaller viewports(devices)✅✅.Reason: User doesn't have to scroll acro
![1](https://user-images.githubusercontent.com/44673237/92999369-f5d38b00-f528-11ea-98d3-1623983286e9.PNG)
![2](https://user-images.githubusercontent.com/44673237/92999367-f409c780-f528-11ea-9e87-601c4263633f.PNG)

ss the page.